### PR TITLE
check role validity on game creation instead of game start

### DIFF
--- a/app/avalon.py
+++ b/app/avalon.py
@@ -89,22 +89,25 @@ def gen_default(n):
         return gen_default(9) + [Role.VANILLA_GOOD]
 
 
-def apply_settings(defaults, mordred, oberon):
+def gen_role_list(num_players, mordred, oberon):
+    roles = gen_default(num_players)
     if mordred:
-        if Role.VANILLA_BAD in defaults:
-            defaults.remove(Role.VANILLA_BAD)
+        if Role.VANILLA_BAD in roles:
+            roles.remove(Role.VANILLA_BAD)
         else:
-            defaults.remove(Role.ASSASSIN)
-        defaults.append(Role.MORDRED)
+            roles.remove(Role.ASSASSIN)
+        roles.append(Role.MORDRED)
 
     if oberon:
-        if Role.VANILLA_BAD in defaults:
-            defaults.remove(Role.VANILLA_BAD)
+        if Role.VANILLA_BAD in roles:
+            roles.remove(Role.VANILLA_BAD)
+        elif Role.ASSASSIN in roles:
+            roles.remove(Role.ASSASSIN)
         else:
-            defaults.remove(Role.ASSASSIN)
-        defaults.append(Role.OBERON)
+            return None
+        roles.append(Role.OBERON)
 
-    return defaults
+    return roles
 
 
 def player_info(game, player):
@@ -124,11 +127,9 @@ def player_info(game, player):
 
     return player_thumbs_seen, player_eyes_seen
 
-
 def assign_roles(game):
     players = game.players()
-    defaults = gen_default(game.num_players)
-    roles = apply_settings(defaults, game.has_mordred, game.has_oberon)
+    roles = gen_role_list(game.num_players, game.has_mordred, game.has_oberon)
     shuffle(roles)
     for player, role in zip(players, roles):
         player.set_role(role)

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -5,7 +5,7 @@ import uuid
 from channels import Group
 from django.db import models
 
-from app.avalon import assign_roles
+from app.avalon import assign_roles, gen_role_list
 from .util import lobby_json
 
 
@@ -15,6 +15,9 @@ class GameManager(models.Manager):
         # For the set of all unstarted games joinable ID must be unique
         while self.filter(is_started=False, joinable_id=joinable_id):
             joinable_id = ''.join(random.choices(string.ascii_uppercase, k=4))
+
+        if not gen_role_list(num_players, has_mordred, has_oberon):
+            return False
 
         game = self.model(joinable_id=joinable_id,
                           num_players=num_players,

--- a/app/views.py
+++ b/app/views.py
@@ -100,6 +100,11 @@ class CreateGameView(View):
             request.POST.get('has_mordred', 'off') == 'on',
             request.POST.get('has_oberon', 'off') == 'on',
         )
+
+        if not game:
+            messages.add_message(request, messages.ERROR, 'Too many spy roles, not enough spies.')
+            return redirect('create_game')
+
         player = Player.players.create_guest_player(
             game=game,
             name=name.title(),


### PR DESCRIPTION
Problem: if you try to make a 5p/6p game with both mordred and oberon, the game crashes. this occurs because if there's no vspy in the default, mordred removes the assassin role, then oberon tries to remove the assassin role.

Deeper problem this exposes: the app doesn't try to actually resolve roles and player count until `game.start` calls `assign_roles`. this is a problem since it's possible for certain arrangements of roles and player count to be invalid, and the user shouldn't have to start a game to find out that their setup was invalid all along.

Fix: check at creation time whether or not the selected roles are valid for that player count. whatever solution we do here should scale up to when we have more roles/custom roles/etc.

i'm not sure about the implementation details of how this should work, this pr is just one potential way to do it. but we definitely need _some_ way to check role validity at game creation time.